### PR TITLE
CAS mismatch should return KEY_EEXISTS on wires

### DIFF
--- a/mock/mockimpl/svcimpls/kvimplcrud.go
+++ b/mock/mockimpl/svcimpls/kvimplcrud.go
@@ -72,7 +72,7 @@ func (x *kvImplCrud) translateProcErr(err error) memd.StatusCode {
 	case kvproc.ErrDocNotFound:
 		return memd.StatusKeyNotFound
 	case kvproc.ErrCasMismatch:
-		return memd.StatusTmpFail
+		return memd.StatusKeyExists
 	case kvproc.ErrLocked:
 		return memd.StatusLocked
 	case kvproc.ErrNotLocked:


### PR DESCRIPTION
https://github.com/couchbase/kv_engine/blob/45f82c3c10ea2099c05ee318d5a0ca222900fcdd/engines/ep/src/vbucket.cc#L1619-L1621