### PR TITLE
Continue on EOF client start

### DIFF
--- a/cmd/api/apiclient.go
+++ b/cmd/api/apiclient.go
@@ -108,7 +108,7 @@ func (c *Client) start() error {
 			pkt, err := c.readPacket()
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					break
+					continue
 				}
 
 				log.Printf("failed to read request: %s", err)
@@ -125,7 +125,7 @@ func (c *Client) start() error {
 			err = c.writePacket(resCmd)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					break
+					continue
 				}
 
 				log.Printf("failed to write response: %s", err)


### PR DESCRIPTION
This is a tiny change but when running gocaves mock tests, including the included examples I'd get intermittent failures with `SOCKET_NOT_AVAILABLE`.

We'd get errors in the logs like so:
```
GOCAVES 17:19:22.231822 api client disconnected: 0xc0000957d0
GOCAVES 17:19:22.231835 sdk disconnected
GOCB 17:19:22.282745 memdclient.go:351: memdClient read failure: EOF
```

Adding this continue essentially means we'll retry on an EOF and this seems to fix the issue. Since adding this I haven't seen the issue crop up again in my own development.