### PR TITLE
Ability to add buckets & a small nodeServices addition

### DIFF
--- a/mock/bucket.go
+++ b/mock/bucket.go
@@ -7,19 +7,33 @@ type BucketType uint
 
 // The following lists the possible bucket types
 const (
-	BucketTypeMemcached = BucketType(1)
-	BucketTypeCouchbase = BucketType(2)
+	BucketTypeMemcached       = BucketType(1)
+	BucketTypeCouchbase       = BucketType(2)
+	BucketTypeMemcachedString = "memcached"
+	BucketTypeCouchbaseString = "membase"
 )
 
 func (b BucketType) Name() string {
 	switch b {
 	case BucketTypeMemcached:
-		return "memcached"
+		return BucketTypeMemcachedString
 	case BucketTypeCouchbase:
-		return "membase"
+		return BucketTypeCouchbaseString
 	}
 
 	return ""
+}
+
+func BucketTypeFromString(bucketTypeString string) BucketType {
+	switch bucketTypeString {
+	case BucketTypeMemcachedString:
+		return BucketTypeMemcached
+	case BucketTypeCouchbaseString:
+		return BucketTypeCouchbase
+	}
+
+	// Default to Couchbase?
+	return BucketTypeCouchbase
 }
 
 // NewBucketOptions allows you to specify initial options for a new bucket

--- a/mock/mockimpl/svcimpls/mgmtimpl.go
+++ b/mock/mockimpl/svcimpls/mgmtimpl.go
@@ -9,6 +9,8 @@ func (x *mgmtImpl) Register(h *hookHelper) {
 	h.RegisterMgmtHandler("GET", "/pools", x.handleGetAllPoolsConfig)
 	h.RegisterMgmtHandler("GET", "/pools/default", x.handleGetPoolConfig)
 	h.RegisterMgmtHandler("GET", "/pools/default/buckets", x.handleGetAllBucketConfigs)
+	h.RegisterMgmtHandler("POST", "/pools/default/buckets", x.handleAddBucketConfig)
+	h.RegisterMgmtHandler("GET", "/pools/default/nodeServices", x.handleGetNodeServices)
 	h.RegisterMgmtHandler("GET", "/pools/default/buckets/*", x.handleGetBucketConfig)
 	h.RegisterMgmtHandler("GET", "/pools/default/b/*", x.handleGetTerseBucketConfig)
 	h.RegisterMgmtHandler("GET", "/pools/default/bs/*", x.handleGetTerseBucketStreamingConfig)


### PR DESCRIPTION
PR adds the ability to add buckets through the REST API. There are a few parameters not getting used yet but this can be added in the future: `flushEnabled`, `ramQuotaMB` and `replicaIndex`.

Also adds a small handler: `nodeServices`. This uses existing functions to return the required data. This is used in some later work.