### PR TITLE
Add mutex to lock store on read / write

### DIFF
--- a/contrib/ctxstore/ctxstore.go
+++ b/contrib/ctxstore/ctxstore.go
@@ -2,11 +2,13 @@ package ctxstore
 
 import (
 	"reflect"
+	"sync"
 )
 
 // Store allows generic contextual data storage
 type Store struct {
-	data map[reflect.Type]reflect.Value
+	data     map[reflect.Type]reflect.Value
+	dataLock sync.Mutex
 }
 
 // Get returns an associated context by its type
@@ -22,6 +24,8 @@ func (s *Store) Get(valuePtr interface{}) {
 	}
 
 	vType := ptrV.Type().Elem()
+	s.dataLock.Lock()
+	defer s.dataLock.Unlock()
 	if s.data != nil {
 		if ctx, ok := s.data[vType]; ok {
 			ptrV.Set(ctx)


### PR DESCRIPTION
When running tests I'd occasionally see the `concurrent map writes` error. Tracked it down and appears to be caused here. This locking fixed the problem.