### PR TITLE
Fix an array of subdoc and xattr operations

### DIFF
--- a/mock/mockimpl/kvproc/errors.go
+++ b/mock/mockimpl/kvproc/errors.go
@@ -28,3 +28,11 @@ var (
 	ErrSdCannotModifyVattr    = errors.New("xattr cannot modify virtual attribute")
 	ErrSdXattrInvalidKeyCombo = errors.New("invalid xattr key combination")
 )
+
+type SubdocMutateError struct {
+	Err error
+}
+
+func (e SubdocMutateError) Error() string {
+	return e.Err.Error()
+}

--- a/mock/mockimpl/kvproc/operations.go
+++ b/mock/mockimpl/kvproc/operations.go
@@ -838,7 +838,7 @@ func (e *Engine) MultiLookup(opts MultiLookupOptions) (*MultiLookupResult, error
 		return nil, ErrLocked
 	}
 
-	sdRes, err := e.executeSdOps(doc, doc, opts.Ops)
+	sdRes, err := e.executeSdOps(doc, doc, opts.Ops, true)
 	if err != nil {
 		return nil, err
 	}
@@ -899,11 +899,13 @@ func (e *Engine) MultiMutate(opts MultiMutateOptions) (*MultiMutateResult, error
 
 		// We need to dynamically decide what the root of the document
 		// needs to look like based on the operations that exist.
+		xattrUpdateOnly := true
 		for _, op := range opts.Ops {
 			if !op.IsXattrPath {
 				if opts.CreateAsDeleted {
 					return nil, ErrInvalidArgument
 				}
+				xattrUpdateOnly = false
 				trimmedPath := strings.TrimSpace(op.Path)
 				if trimmedPath == "" {
 					switch op.Op {
@@ -933,7 +935,9 @@ func (e *Engine) MultiMutate(opts MultiMutateOptions) (*MultiMutateResult, error
 
 		// Check for cas mismatch before we do any work. We'll effectively be doing this check again during the update
 		// too so if anyone performs a mutation during that time then we'll catch it there too.
-		if opts.Cas != 0 && doc.Cas != opts.Cas {
+		// If doc is deleted, and we're only updating the tombstoned xattr then no cas mismatch is performed, so we can
+		// continue
+		if opts.Cas != 0 && doc.Cas != opts.Cas && !(doc.IsDeleted && !xattrUpdateOnly) {
 			return nil, ErrCasMismatch
 		}
 
@@ -946,6 +950,7 @@ func (e *Engine) MultiMutate(opts MultiMutateOptions) (*MultiMutateResult, error
 				doc = mdoc
 			} else if doc.IsDeleted && !opts.AccessDeleted {
 				doc.IsDeleted = false
+				doc.Expiry = time.Time{} // If a doc is resurrected we also need to reset expiry
 			}
 		}
 
@@ -965,7 +970,7 @@ func (e *Engine) MultiMutate(opts MultiMutateOptions) (*MultiMutateResult, error
 			Cas: mockdb.GenerateNewCas(e.HLC()),
 		}
 
-		sdRes, err := e.executeSdOps(doc, newMetaDoc, opts.Ops)
+		sdRes, err := e.executeSdOps(doc, newMetaDoc, opts.Ops, false)
 		if err != nil {
 			return nil, err
 		}
@@ -998,6 +1003,7 @@ func (e *Engine) MultiMutate(opts MultiMutateOptions) (*MultiMutateResult, error
 
 				idoc.LockExpiry = newMetaDoc.LockExpiry
 				idoc.Cas = newMetaDoc.Cas
+				idoc.Datatype = uint8(memd.DatatypeFlagJSON)
 				return idoc, nil
 			})
 		if err == ErrCasMismatch {

--- a/mock/mockimpl/svcimpls/kvimplcrud.go
+++ b/mock/mockimpl/svcimpls/kvimplcrud.go
@@ -858,6 +858,7 @@ func (x *kvImplCrud) handleMultiLookupRequest(source mock.KvClient, pak *memd.Pa
 		}
 
 		valueBytes := make([]byte, 0)
+		anOperationFailed := false
 		for _, opRes := range resp.Ops {
 			opBytes := make([]byte, 6)
 			resStatus := x.translateProcErr(opRes.Err)
@@ -867,11 +868,23 @@ func (x *kvImplCrud) handleMultiLookupRequest(source mock.KvClient, pak *memd.Pa
 			opBytes = append(opBytes, opRes.Value...)
 
 			valueBytes = append(valueBytes, opBytes...)
+
+			if opRes.Err != nil {
+				anOperationFailed = true
+			}
 		}
 
 		status := memd.StatusSuccess
 		if resp.IsDeleted {
 			status = memd.StatusSubDocSuccessDeleted
+		}
+
+		if anOperationFailed {
+			if resp.IsDeleted {
+				status = memd.StatusSubDocMultiPathFailureDeleted
+			} else {
+				status = memd.StatusSubDocBadMulti
+			}
 		}
 
 		writePacketToSource(source, &memd.Packet{
@@ -1041,6 +1054,10 @@ func (x *kvImplCrud) handleMultiMutateRequest(source mock.KvClient, pak *memd.Pa
 			Cas:             pak.Cas,
 		})
 		if err != nil {
+			if e, ok := err.(kvproc.SubdocMutateError); ok {
+				x.writeSubdocMutateErr(source, pak, start, 0, e.Err)
+				return
+			}
 			x.writeProcErr(source, pak, err, start)
 			return
 		}
@@ -1053,21 +1070,7 @@ func (x *kvImplCrud) handleMultiMutateRequest(source mock.KvClient, pak *memd.Pa
 		}
 
 		if failedOpIdx >= 0 {
-			resStatus := x.translateProcErr(resp.Ops[failedOpIdx].Err)
-
-			valueBytes := make([]byte, 3)
-			valueBytes[0] = uint8(failedOpIdx)
-			binary.BigEndian.PutUint16(valueBytes[1:], uint16(resStatus))
-
-			// TODO(brett19): Confirm that sub-document errors return 0 CAS.
-			writePacketToSource(source, &memd.Packet{
-				Magic:   memd.CmdMagicRes,
-				Command: pak.Command,
-				Opaque:  pak.Opaque,
-				Status:  memd.StatusSubDocBadMulti,
-				Cas:     0,
-				Value:   valueBytes,
-			}, start)
+			x.writeSubdocMutateErr(source, pak, start, failedOpIdx, resp.Ops[failedOpIdx].Err)
 			return
 		}
 
@@ -1105,6 +1108,23 @@ func (x *kvImplCrud) handleMultiMutateRequest(source mock.KvClient, pak *memd.Pa
 			Extras:  extrasBuf,
 		}, start)
 	}
+}
+
+func (x *kvImplCrud) writeSubdocMutateErr(source mock.KvClient, pak *memd.Packet, start time.Time, errIdx int, err error) {
+	resStatus := x.translateProcErr(err)
+
+	valueBytes := make([]byte, 3)
+	valueBytes[0] = uint8(0)
+	binary.BigEndian.PutUint16(valueBytes[1:], uint16(resStatus))
+
+	writePacketToSource(source, &memd.Packet{
+		Magic:   memd.CmdMagicRes,
+		Command: pak.Command,
+		Opaque:  pak.Opaque,
+		Status:  memd.StatusSubDocBadMulti,
+		Cas:     0,
+		Value:   valueBytes,
+	}, start)
 }
 
 func (x *kvImplCrud) handleObserveSeqNo(source mock.KvClient, pak *memd.Packet, start time.Time) {


### PR DESCRIPTION
This PR includes various subdoc and xattr operation fixes:
- On subdoc insert errors it would previously continue with the operation resulting in nilling out the doc we now correctly error
- Now set the correct CRC32 of 0x00... when a macro is specified for a tombstoned document
- CAS is set correctly now on the CAS macro, it was encoded the 'wrong way around' before when compared to CBS
- Return cas mismatches correctly depending on if doc is deleted and whether we're talking to system xattr
- Errors returned for multi mutate around deleted docs have been fixed:
	- StatusSubDocMultiPathFailureDeleted / StatusSubDocBadMulti
	
	
This PR is a fairly large one but felt that these should all be included in one PR. I've tried to comment a good portion of it but if anything isn't clear or looks wrong I'm happy to answer any questions.