### PR TITLE
Fix view filtering

### DIFF
--- a/mock/mockimpl/svcimpls/viewimplquery.go
+++ b/mock/mockimpl/svcimpls/viewimplquery.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"log"
+	"strconv"
+	"strings"
+
 	"github.com/couchbaselabs/gocaves/contrib/pathparse"
 	"github.com/couchbaselabs/gocaves/mock"
 	"github.com/couchbaselabs/gocaves/mock/mockauth"
 	"github.com/couchbaselabs/gocaves/mock/mockmr"
-	"log"
-	"strconv"
-	"strings"
 )
 
 type viewImplQuery struct {
@@ -74,6 +75,11 @@ func (x *viewImplQuery) handleQuery(source mock.ViewService, req *mock.HTTPReque
 	}
 
 	keysOpt := options.Get("keys")
+	// Strip out the "[]" notation for keys filters
+	if len(keysOpt) >= 2 && keysOpt[0:1] == "[" && keysOpt[len(keysOpt)-2:len(keysOpt)-1] == "]" {
+		keysOpt = keysOpt[1:len(keysOpt)-2] + keysOpt[len(keysOpt):]
+	}
+
 	var keys []string
 	if keysOpt != "" {
 		keys = strings.Split(keysOpt, ",")


### PR DESCRIPTION
PR fixes views when filtering on keys:
- Clears out `\n` characters from filters
- Extracts the `[]` characters when including multiple keys
- Flips the comparison field on the end key filters, these were incorrect
- Fixed a limit crash when output was nil

This PR was originally to also include [`bc12c36` (#75)](https://github.com/couchbaselabs/gocaves/pull/75/commits/bc12c369914c88b65d374e36053319ba9d803f96) however I noticed that this has also been included in https://github.com/couchbaselabs/gocaves/pull/75 now.