### PR TITLE
Don't fail xattr subdoc if doc was deleted during current operation

### DIFF
--- a/mock/mockimpl/kvproc/subdoc.go
+++ b/mock/mockimpl/kvproc/subdoc.go
@@ -60,6 +60,7 @@ func (e *Engine) executeSdOps(doc, newMeta *mockdb.Document, ops []*SubDocOp, co
 
 	reorderedOps := subdocReorder(ops)
 
+	var wasDeleted bool
 	seenXattrRoots := make(map[string]struct{})
 	for opIdx, op := range reorderedOps.ops {
 		var opDoc *mockdb.Document
@@ -82,7 +83,7 @@ func (e *Engine) executeSdOps(doc, newMeta *mockdb.Document, ops []*SubDocOp, co
 
 			// If doc is deleted we can only access system xattrs. System xattrs are those with begin with an
 			// underscore.
-			if !strings.HasPrefix(path, "_") && doc.IsDeleted {
+			if !strings.HasPrefix(path, "_") && doc.IsDeleted && !wasDeleted {
 				opReses[reorderedOps.indexes[opIdx]] = &SubDocResult{
 					Value: nil,
 					Err:   ErrSdPathNotFound,
@@ -170,6 +171,7 @@ func (e *Engine) executeSdOps(doc, newMeta *mockdb.Document, ops []*SubDocOp, co
 				baseSubDocExecutor: base,
 			}
 		case memd.SubDocOpDeleteDoc:
+			wasDeleted = true
 			executor = SubDocDeleteFullDocExecutor{
 				baseSubDocExecutor: base,
 			}


### PR DESCRIPTION
We reorder operations so that xattrs are done last (presumably so
that things like expand macros use the correct values) which means
that if any non-xattr ops are a full doc remove then the xattr
operation itself will fail. This shouldn't be the case.